### PR TITLE
Tensor lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ bitflags = "2.6.0"
 [lints.rust]
 private_bounds = "allow"
 dead_code = "allow"
+
+[profile.release]
+debug = true
+strip = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 name = "fill_f32"
 path = "benches/fill_f32.rs"
 
+[[bin]]
+name = "fill_f32_slice"
+path = "benches/fill_f32_slice.rs"
+
 [dependencies]
 cpu-time = "1.0.0"
 bitflags = "2.6.0"

--- a/benches/fill_f32_slice.py
+++ b/benches/fill_f32_slice.py
@@ -1,0 +1,33 @@
+import numpy as np
+import torch
+
+from perfprofiler import *
+
+
+class TensorFill(TimingSuite):
+    def __init__(self, n):
+        self.n = n
+
+        self.ndarray: np.ndarray = np.zeros((n, 2), dtype="float32")
+        self.ndarray_slice = self.ndarray[:, 0]
+
+        self.tensor_cpu = torch.zeros((n, 2), dtype=torch.float32)
+        self.tensor_cpu_slice = self.tensor_cpu[:, 0]
+
+    @measure_performance("NumPy")
+    def run(self):
+        self.ndarray_slice.fill(5.0)
+
+    @measure_performance("PyTorch CPU")
+    def run(self):
+        self.tensor_cpu_slice.fill_(5.0)
+
+    @measure_rust_performance("Chela CPU", target="fill_f32_slice")
+    def run(self, executable):
+        return self.run_rust(executable, self.n)
+
+
+if __name__ == "__main__":
+    sizes = [2 ** n for n in range(9, 25)]
+    results = TensorFill.profile_each(sizes, n=10)
+    plot_results(sizes, results, "tensor.fill() CPU time vs length")

--- a/benches/fill_f32_slice.rs
+++ b/benches/fill_f32_slice.rs
@@ -1,0 +1,21 @@
+use chela::*;
+use std::env;
+
+use cpu_time::ProcessTime;
+
+
+fn profile(size: usize) -> u128 {
+    let tensor = Tensor::zeros([size, 2]);
+    let mut tensor_slice = tensor.slice(s![.., 0]);
+
+    let start = ProcessTime::now();
+    tensor_slice.fill(5_f32);
+    start.elapsed().as_nanos()
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let size = args[1].parse::<usize>().unwrap();
+
+    println!("{}", profile(size));
+}

--- a/benches/fill_f32_slice.rs
+++ b/benches/fill_f32_slice.rs
@@ -15,7 +15,7 @@ fn profile(size: usize) -> u128 {
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let size = args[1].parse::<usize>().unwrap();
+    let size = if args.len() < 2 { 65536 } else { args[1].parse().unwrap() };
 
     println!("{}", profile(size));
 }

--- a/src/axis/index.rs
+++ b/src/axis/index.rs
@@ -27,10 +27,7 @@ impl Indexer for Index {
     }
 
     fn collapse_dimension(&self) -> bool {
-        match self {
-            Index::Usize(_) => true,
-            _ => false,
-        }
+        matches!(self, Index::Usize(_))
     }
 }
 

--- a/src/axis/index.rs
+++ b/src/axis/index.rs
@@ -1,6 +1,6 @@
 use crate::axis::indexer::Indexer;
-use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 use crate::axis::indexer_impl::IndexerImpl;
+use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 #[derive(Clone)]
 pub enum Index {
@@ -25,18 +25,25 @@ impl Indexer for Index {
             Index::RangeToInclusive(index) => index.index_of_first_element(),
         }
     }
+
+    fn collapse_dimension(&self) -> bool {
+        match self {
+            Index::Usize(_) => true,
+            _ => false,
+        }
+    }
 }
 
 impl IndexerImpl for Index {
-    fn len(&self, axis: usize, shape: &[usize]) -> usize {
+    fn indexed_length(&self, len: usize) -> usize {
         match self {
-            Index::Usize(index) => IndexerImpl::len(index, axis, shape),
-            Index::Range(index) => IndexerImpl::len(index, axis, shape),
-            Index::RangeFrom(index) => IndexerImpl::len(index, axis, shape),
-            Index::RangeFull(index) => IndexerImpl::len(index, axis, shape),
-            Index::RangeInclusive(index) => IndexerImpl::len(index, axis, shape),
-            Index::RangeTo(index) => IndexerImpl::len(index, axis, shape),
-            Index::RangeToInclusive(index) => IndexerImpl::len(index, axis, shape),
+            Index::Usize(index) => IndexerImpl::indexed_length(index, len),
+            Index::Range(index) => IndexerImpl::indexed_length(index, len),
+            Index::RangeFrom(index) => IndexerImpl::indexed_length(index, len),
+            Index::RangeFull(index) => IndexerImpl::indexed_length(index, len),
+            Index::RangeInclusive(index) => IndexerImpl::indexed_length(index, len),
+            Index::RangeTo(index) => IndexerImpl::indexed_length(index, len),
+            Index::RangeToInclusive(index) => IndexerImpl::indexed_length(index, len),
         }
     }
 }

--- a/src/axis/indexer.rs
+++ b/src/axis/indexer.rs
@@ -1,32 +1,21 @@
-use crate::Axis;
-
-use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 use crate::axis::indexer_impl::IndexerImpl;
+use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 pub(crate) trait Indexer: IndexerImpl + Clone {
-    fn indexed_shape_and_stride(&self, axis: &Axis, shape: &[usize], stride: &[usize]) -> (Vec<usize>, Vec<usize>) {
-        let mut shape = shape.to_vec();
-        let mut stride = stride.to_vec();
-
-        let axis = axis.0;
-        let len = self.len(axis, &shape);
-
-        if len == 0 {
-            shape.remove(axis);
-            stride.remove(axis);
-        } else {
-            shape[axis] = len;
-        }
-
-        (shape, stride)
-    }
-
     fn index_of_first_element(&self) -> usize;
+
+    fn collapse_dimension(&self) -> bool {
+        false
+    }
 }
 
 impl Indexer for usize {
     fn index_of_first_element(&self) -> usize {
         *self
+    }
+
+    fn collapse_dimension(&self) -> bool {
+        true
     }
 }
 impl Indexer for Range<usize> {

--- a/src/axis/indexer_impl.rs
+++ b/src/axis/indexer_impl.rs
@@ -5,12 +5,12 @@ pub(crate) trait IndexerImpl {
 }
 
 impl IndexerImpl for usize {
-    fn indexed_length(&self, axis_length: usize) -> usize {
+    fn indexed_length(&self, _axis_length: usize) -> usize {
         1
     }
 }
 impl IndexerImpl for Range<usize> {
-    fn indexed_length(&self, axis_length: usize) -> usize {
+    fn indexed_length(&self, _axis_length: usize) -> usize {
         self.end - self.start
     }
 }
@@ -28,19 +28,19 @@ impl IndexerImpl for RangeFrom<usize> {
 }
 
 impl IndexerImpl for RangeTo<usize> {
-    fn indexed_length(&self, axis_length: usize) -> usize {
+    fn indexed_length(&self, _axis_length: usize) -> usize {
         self.end
     }
 }
 
 impl IndexerImpl for RangeInclusive<usize> {
-    fn indexed_length(&self, axis_length: usize) -> usize {
+    fn indexed_length(&self, _axis_length: usize) -> usize {
         self.end() - self.start() + 1
     }
 }
 
 impl IndexerImpl for RangeToInclusive<usize> {
-    fn indexed_length(&self, axis_length: usize) -> usize {
+    fn indexed_length(&self, _axis_length: usize) -> usize {
         self.end + 1
     }
 }

--- a/src/axis/indexer_impl.rs
+++ b/src/axis/indexer_impl.rs
@@ -1,46 +1,46 @@
 use std::ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
-pub(super) trait IndexerImpl {
-    fn len(&self, axis: usize, shape: &[usize]) -> usize;
+pub(crate) trait IndexerImpl {
+    fn indexed_length(&self, axis_length: usize) -> usize;
 }
 
 impl IndexerImpl for usize {
-    fn len(&self, _axis: usize, _shape: &[usize]) -> usize {
-        0
+    fn indexed_length(&self, axis_length: usize) -> usize {
+        1
     }
 }
 impl IndexerImpl for Range<usize> {
-    fn len(&self, _axis: usize, _shape: &[usize]) -> usize {
+    fn indexed_length(&self, axis_length: usize) -> usize {
         self.end - self.start
     }
 }
 
 impl IndexerImpl for RangeFull {
-    fn len(&self, axis: usize, shape: &[usize]) -> usize {
-        shape[axis]
+    fn indexed_length(&self, axis_length: usize) -> usize {
+        axis_length
     }
 }
 
 impl IndexerImpl for RangeFrom<usize> {
-    fn len(&self, axis: usize, shape: &[usize]) -> usize {
-        shape[axis] - self.start
+    fn indexed_length(&self, axis_length: usize) -> usize {
+        axis_length - self.start
     }
 }
 
 impl IndexerImpl for RangeTo<usize> {
-    fn len(&self, _axis: usize, _shape: &[usize]) -> usize {
+    fn indexed_length(&self, axis_length: usize) -> usize {
         self.end
     }
 }
 
 impl IndexerImpl for RangeInclusive<usize> {
-    fn len(&self, _axis: usize, _shape: &[usize]) -> usize {
+    fn indexed_length(&self, axis_length: usize) -> usize {
         self.end() - self.start() + 1
     }
 }
 
 impl IndexerImpl for RangeToInclusive<usize> {
-    fn len(&self, _axis: usize, _shape: &[usize]) -> usize {
+    fn indexed_length(&self, axis_length: usize) -> usize {
         self.end + 1
     }
 }

--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -1,3 +1,6 @@
+use std::marker::PhantomData;
+use std::ptr::NonNull;
+
 pub mod constructors;
 pub mod dtype;
 
@@ -12,14 +15,12 @@ pub mod equals;
 mod flags;
 
 use crate::dtype::RawDataType;
+use crate::tensor::flags::TensorFlags;
 
 pub use iterator::*;
 
-use crate::tensor::flags::TensorFlags;
-use std::ptr::NonNull;
-
 #[derive(Debug)]
-pub struct Tensor<T: RawDataType> {
+pub struct Tensor<'a, T: RawDataType> {
     ptr: NonNull<T>,
     len: usize,
     capacity: usize,
@@ -27,4 +28,6 @@ pub struct Tensor<T: RawDataType> {
     shape: Vec<usize>,
     stride: Vec<usize>,
     flags: TensorFlags,
+
+    _marker: PhantomData<&'a T>,
 }

--- a/src/tensor/clone.rs
+++ b/src/tensor/clone.rs
@@ -4,14 +4,11 @@ use crate::iterator::flat_index_generator::FlatIndexGenerator;
 use crate::Tensor;
 use std::ptr::copy_nonoverlapping;
 
-impl<T: RawDataType> Clone for Tensor<T> {
-    fn clone(&self) -> Self {
+impl<'a, T: RawDataType> Tensor<'a, T> {
+    pub fn clone<'b>(&'a self) -> Tensor<'b, T> {
         unsafe { Tensor::from_contiguous_owned_buffer(self.shape.clone(), self.clone_data()) }
     }
-}
 
-
-impl<T: RawDataType> Tensor<T> {
     pub(super) fn clone_data(&self) -> Vec<T> {
         if self.is_contiguous() {
             return unsafe { self.clone_data_contiguous() };

--- a/src/tensor/clone.rs
+++ b/src/tensor/clone.rs
@@ -1,5 +1,5 @@
 use crate::dtype::RawDataType;
-use crate::iterator::collapse_contiguous::{collapse_contiguous, collapse_to_uniform_stride};
+use crate::iterator::collapse_contiguous::{collapse_to_uniform_stride};
 use crate::iterator::flat_index_generator::FlatIndexGenerator;
 use crate::Tensor;
 use std::ptr::copy_nonoverlapping;

--- a/src/tensor/clone.rs
+++ b/src/tensor/clone.rs
@@ -57,7 +57,7 @@ impl<T: RawDataType> Tensor<T> {
         let mut dst = data.as_mut_ptr();
 
         for i in FlatIndexGenerator::from(&shape, &stride) {
-            copy_nonoverlapping(src.offset(i), dst, contiguous_stride);
+            copy_nonoverlapping(src.add(i), dst, contiguous_stride);
             dst = dst.add(contiguous_stride);
         }
 

--- a/src/tensor/clone.rs
+++ b/src/tensor/clone.rs
@@ -1,5 +1,5 @@
 use crate::dtype::RawDataType;
-use crate::iterator::collapse_contiguous::collapse_contiguous;
+use crate::iterator::collapse_contiguous::{collapse_contiguous, collapse_to_uniform_stride};
 use crate::iterator::flat_index_generator::FlatIndexGenerator;
 use crate::Tensor;
 use std::ptr::copy_nonoverlapping;
@@ -33,7 +33,7 @@ impl<T: RawDataType> Tensor<T> {
         let size = self.size();
         let mut data = Vec::with_capacity(size);
 
-        let (mut shape, mut stride) = collapse_contiguous(&self.shape, &self.stride);
+        let (mut shape, mut stride) = collapse_to_uniform_stride(&self.shape, &self.stride);
 
         // safe to unwrap because if stride has no elements, this would be a scalar tensor
         // however, scalar tensors are contiguously stored so this method wouldn't be called

--- a/src/tensor/constructors.rs
+++ b/src/tensor/constructors.rs
@@ -23,7 +23,7 @@ fn stride_from_shape(shape: &[usize]) -> Vec<usize> {
     stride
 }
 
-impl<T: RawDataType> Tensor<T> {
+impl<T: RawDataType> Tensor<'_, T> {
     /// Safety: ensure data is non-empty and shape & stride matches data buffer
     pub(super) unsafe fn from_owned_buffer(shape: Vec<usize>, stride: Vec<usize>, data: Vec<T>) -> Self {
         // take control of the data so that Rust doesn't drop it once the vector goes out of scope
@@ -37,6 +37,8 @@ impl<T: RawDataType> Tensor<T> {
             shape,
             stride,
             flags: TensorFlags::Owned | TensorFlags::Contiguous,
+
+            _marker: Default::default(),
         }
     }
 
@@ -91,7 +93,7 @@ impl<T: RawDataType> Tensor<T> {
     }
 }
 
-impl<T: RawDataType> Drop for Tensor<T> {
+impl<T: RawDataType> Drop for Tensor<'_, T> {
     fn drop(&mut self) {
         if self.flags.contains(TensorFlags::Owned) {
             // drops the data

--- a/src/tensor/equals.rs
+++ b/src/tensor/equals.rs
@@ -1,7 +1,7 @@
 use crate::dtype::RawDataType;
 use crate::Tensor;
 
-impl<T1, T2> PartialEq<Tensor<T1>> for Tensor<T2>
+impl<T1, T2> PartialEq<Tensor<'_, T1>> for Tensor<'_, T2>
 where
     T1: RawDataType,
     T2: RawDataType + From<T1>,

--- a/src/tensor/fill.rs
+++ b/src/tensor/fill.rs
@@ -14,7 +14,9 @@ impl<T: RawDataType> Tensor<T> {
     }
 
     fn fill_non_contiguous(&mut self, value: T) {
-        todo!()
+        for ptr in self.flatiter_ptr() {
+            unsafe { std::ptr::write(ptr, value); }
+        }
     }
 
     // TODO we can probably make further optimisations in cases where the tensor isn't contiguous,

--- a/src/tensor/fill.rs
+++ b/src/tensor/fill.rs
@@ -17,6 +17,13 @@ impl<T: RawDataType> Tensor<T> {
         todo!()
     }
 
+    // TODO we can probably make further optimisations in cases where the tensor isn't contiguous,
+    // but where each element is located at a uniform stride from each other.
+    // For example, let tensor = zeros(5, 2); view = tensor[::2
+    // Then, each element of view is distributed with a stride of 2.
+    // However, let tensor = zeros(4, 2); view = tensor[::2]
+    // Then, view does not have a uniform stride because of elements at the boundary of axes 0 & 1
+
     pub fn fill(&mut self, value: T) {
         if self.is_contiguous() {
             return unsafe { self.fill_contiguous(value) };

--- a/src/tensor/fill.rs
+++ b/src/tensor/fill.rs
@@ -20,7 +20,7 @@ unsafe fn fill_shape_and_stride<T: Copy>(mut start: *mut T, value: T, shape: &[u
     }
 }
 
-impl<T: RawDataType> Tensor<T> {
+impl<T: RawDataType> Tensor<'_, T> {
     pub fn fill(&mut self, value: T) {
         if self.is_contiguous() {
             return unsafe { fill_strided(self.ptr.as_ptr(), value, 1, self.len); };

--- a/src/tensor/index_impl.rs
+++ b/src/tensor/index_impl.rs
@@ -2,7 +2,7 @@ use crate::dtype::RawDataType;
 use crate::Tensor;
 use std::ops::Index;
 
-impl<T: RawDataType, const D: usize> Index<[usize; D]> for Tensor<T> {
+impl<T: RawDataType, const D: usize> Index<[usize; D]> for Tensor<'_, T> {
     type Output = T;
 
     fn index(&self, index: [usize; D]) -> &Self::Output {
@@ -17,7 +17,7 @@ impl<T: RawDataType, const D: usize> Index<[usize; D]> for Tensor<T> {
     }
 }
 
-impl<T: RawDataType> Index<usize> for Tensor<T> {
+impl<T: RawDataType> Index<usize> for Tensor<'_, T> {
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/src/tensor/iterator/buffer_iterator.rs
+++ b/src/tensor/iterator/buffer_iterator.rs
@@ -3,26 +3,26 @@ use crate::flat_index_generator::FlatIndexGenerator;
 use crate::Tensor;
 
 pub struct BufferIterator<T: RawDataType> {
-    ptr: *const T,
+    ptr: *mut T,
     indices: FlatIndexGenerator,
 }
 
 impl<T: RawDataType> BufferIterator<T> {
-    pub(super) fn from(tensor: &Tensor<T>, indices: FlatIndexGenerator) -> Self {
+    pub(super) fn from(tensor: &Tensor<T>) -> Self {
         Self {
             ptr: tensor.ptr.as_ptr(),
-            indices,
+            indices: FlatIndexGenerator::from(&tensor.shape, &tensor.stride),
         }
     }
 }
 
 impl<T: RawDataType> Iterator for BufferIterator<T> {
-    type Item = T;
+    type Item = *mut T;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.indices.next() {
             None => None,
-            Some(i) => Some(unsafe { *self.ptr.offset(i) })
+            Some(i) => Some(unsafe { self.ptr.add(i) })
         }
     }
 }

--- a/src/tensor/iterator/collapse_contiguous.rs
+++ b/src/tensor/iterator/collapse_contiguous.rs
@@ -42,9 +42,51 @@ pub(in crate::tensor) fn is_contiguous(shape: &[usize], stride: &[usize]) -> boo
     true
 }
 
+// Examples
+//
+// shape (2, 3), stride (3, 1) -> shape (6,), stride (1,)
+// [[0, 1, 2], [3, 4, 5]] -> [0, 1, 2, 3, 4, 5]
+//
+// shape (2, 3), stride (6, 2) -> shape (6,), stride (2,)
+// [[0, 2, 4], [6, 8, 10]] -> [0, 2, 4, 6, 8, 10]
+//
+// shape (2, 3), stride (5, 2) -> shape (2, 3), stride (5, 2)
+// [[0, 2, 4], [5, 7, 9]] -> [[0, 2, 4], [5, 7, 9]]
+//
+// shape (2, 2, 2), stride (6, 3, 2) -> shape (4, 2), stride (3, 2)
+// [[[0, 2], [3, 5]], [[6, 8], [9, 11]]] -> [[0, 2], [3, 5], [6, 8], [9, 11]]
+pub(in crate::tensor) fn collapse_to_uniform_stride(shape: &[usize], stride: &[usize]) -> (Vec<usize>, Vec<usize>) {
+    let ndims = shape.len();
+    if ndims == 0 {
+        return (vec![], vec![]);
+    }
+
+    let mut new_shape = Vec::with_capacity(ndims);
+    let mut new_stride = Vec::with_capacity(ndims);
+
+    new_shape.push(shape[0]);
+    new_stride.push(stride[0]);
+
+    let mut last_idx = 0;
+
+    for i in 1..ndims {
+        // check if this dimension can be collapsed into the previous one
+        if stride[i] == new_shape[last_idx] * new_stride[last_idx] {
+            new_shape[last_idx] *= shape[i];  // collapse by merging dimension into the previous one
+        } else {
+            new_shape.push(shape[i]);  // otherwise, start a new dimension
+            new_stride.push(stride[i]);
+            last_idx += 1;
+        }
+    }
+
+    (new_shape, new_stride)
+}
+
 #[cfg(test)]
 mod tests {
     use super::collapse_contiguous;
+    use crate::iterator::collapse_contiguous::collapse_to_uniform_stride;
     use crate::{s, Tensor};
 
     #[test]
@@ -73,5 +115,78 @@ mod tests {
         let (shape, stride) = collapse_contiguous(&b.shape, &b.stride);
         assert_eq!(shape, [2, 2]);
         assert_eq!(stride, [6, 1]);
+    }
+
+    // courtesy of ChatGPT
+    fn test_collapse_to_uniform_stride() {
+        // Example 1
+        let shape = [2, 3];
+        let stride = [3, 1];
+        let (a, b) = collapse_to_uniform_stride(&shape, &stride);
+        assert_eq!(a, [6]);
+        assert_eq!(b, [1]); // Collapsed stride should match the inner-most dimension's stride.
+
+        // Example 2
+        let shape = [2, 3];
+        let stride = [6, 2];
+        let (a, b) = collapse_to_uniform_stride(&shape, &stride);
+        assert_eq!(a, [6]);
+        assert_eq!(b, [2]); // Collapsed as strides are consistent.
+
+        // Example 3
+        let shape = [2, 3];
+        let stride = [5, 2];
+        let (a, b) = collapse_to_uniform_stride(&shape, &stride);
+        assert_eq!(a, [2, 3]);
+        assert_eq!(b, [5, 2]); // Cannot collapse due to inconsistent strides.
+
+        // Example 4
+        let shape = [2, 2, 2];
+        let stride = [6, 3, 2];
+        let (a, b) = collapse_to_uniform_stride(&shape, &stride);
+        assert_eq!(a, [4, 2]);
+        assert_eq!(b, [3, 2]); // Collapsed outer two dimensions.
+
+        // Additional Example 1
+        let shape = [3, 4, 5];
+        let stride = [20, 5, 1];
+        let (a, b) = collapse_to_uniform_stride(&shape, &stride);
+        assert_eq!(a, [60]);
+        assert_eq!(b, [1]); // Fully collapsed due to consistent strides.
+
+        // Additional Example 2
+        let shape = [4, 5, 6];
+        let stride = [30, 6, 1];
+        let (a, b) = collapse_to_uniform_stride(&shape, &stride);
+        assert_eq!(a, [120]);
+        assert_eq!(b, [1]); // Fully collapsed due to consistent strides.
+
+        // Additional Example 3
+        let shape = [3, 3, 3];
+        let stride = [9, 3, 1];
+        let (a, b) = collapse_to_uniform_stride(&shape, &stride);
+        assert_eq!(a, [27]);
+        assert_eq!(b, [1]); // Fully collapsed into a single dimension.
+
+        // Edge Case: Empty shape and stride
+        let shape = [];
+        let stride = [];
+        let (a, b) = collapse_to_uniform_stride(&shape, &stride);
+        assert_eq!(a, []);
+        assert_eq!(b, []); // Should handle empty inputs correctly.
+
+        // Edge Case: Single dimension
+        let shape = [10];
+        let stride = [1];
+        let (a, b) = collapse_to_uniform_stride(&shape, &stride);
+        assert_eq!(a, [10]);
+        assert_eq!(b, [1]); // Single dimension remains unchanged.
+
+        // Edge Case: Non-contiguous strides
+        let shape = [2, 3];
+        let stride = [4, 2];
+        let (a, b) = collapse_to_uniform_stride(&shape, &stride);
+        assert_eq!(a, [2, 3]);
+        assert_eq!(b, [4, 2]); // Cannot collapse due to non-contiguous strides.
     }
 }

--- a/src/tensor/iterator/flat_index_generator.rs
+++ b/src/tensor/iterator/flat_index_generator.rs
@@ -31,14 +31,14 @@ impl FlatIndexGenerator {
 }
 
 impl Iterator for FlatIndexGenerator {
-    type Item = isize;
+    type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.iterator_index == self.size {
             return None;
         }
 
-        let return_index = self.flat_index as isize;
+        let return_index = self.flat_index;
 
         for i in (0..self.shape.len()).rev() {
             self.indices[i] += 1;

--- a/src/tensor/iterator/flat_index_generator.rs
+++ b/src/tensor/iterator/flat_index_generator.rs
@@ -1,4 +1,4 @@
-use crate::iterator::collapse_contiguous::collapse_contiguous;
+use crate::iterator::collapse_contiguous::{collapse_to_uniform_stride};
 
 #[non_exhaustive]
 pub struct FlatIndexGenerator
@@ -15,7 +15,7 @@ pub struct FlatIndexGenerator
 
 impl FlatIndexGenerator {
     pub(in crate::tensor) fn from(shape: &[usize], stride: &[usize]) -> Self {
-        let (shape, stride) = collapse_contiguous(shape, stride);
+        let (shape, stride) = collapse_to_uniform_stride(shape, stride);
         let ndims = shape.len();
         let size = shape.iter().product();
 

--- a/src/tensor/iterator/flat_iterator.rs
+++ b/src/tensor/iterator/flat_iterator.rs
@@ -1,0 +1,26 @@
+use crate::buffer_iterator::BufferIterator;
+use crate::dtype::RawDataType;
+use crate::Tensor;
+
+pub struct FlatIterator<T: RawDataType> {
+    buffer_iterator: BufferIterator<T>,
+}
+
+impl<T: RawDataType> FlatIterator<T> {
+    pub(super) fn from(tensor: &Tensor<T>) -> Self {
+        Self {
+            buffer_iterator: BufferIterator::from(tensor),
+        }
+    }
+}
+
+impl<T: RawDataType> Iterator for FlatIterator<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.buffer_iterator.next() {
+            None => None,
+            Some(ptr) => Some(unsafe { *ptr })
+        }
+    }
+}

--- a/src/tensor/iterator/iterators.rs
+++ b/src/tensor/iterator/iterators.rs
@@ -1,15 +1,12 @@
 use crate::dtype::RawDataType;
-use crate::iterator::buffer_iterator::BufferIterator;
-use crate::iterator::flat_index_generator::FlatIndexGenerator;
+use crate::iterator::flat_iterator::FlatIterator;
 use crate::tensor_iterator::NdIterator;
 use crate::traits::haslength::HasLength;
 use crate::{AxisType, Tensor};
 
-
 impl<T: RawDataType> Tensor<T> {
-    pub fn flatiter(&self) -> BufferIterator<T> {
-        let indices = FlatIndexGenerator::from(&self.shape, &self.stride);
-        BufferIterator::from(self, indices)
+    pub fn flatiter(&self) -> FlatIterator<T> {
+        FlatIterator::from(self)
     }
 }
 

--- a/src/tensor/iterator/iterators.rs
+++ b/src/tensor/iterator/iterators.rs
@@ -3,10 +3,15 @@ use crate::iterator::flat_iterator::FlatIterator;
 use crate::tensor_iterator::NdIterator;
 use crate::traits::haslength::HasLength;
 use crate::{AxisType, Tensor};
+use crate::buffer_iterator::BufferIterator;
 
 impl<T: RawDataType> Tensor<T> {
     pub fn flatiter(&self) -> FlatIterator<T> {
         FlatIterator::from(self)
+    }
+
+    pub fn flatiter_ptr(&self) -> BufferIterator<T> {
+        BufferIterator::from(self)
     }
 }
 

--- a/src/tensor/iterator/iterators.rs
+++ b/src/tensor/iterator/iterators.rs
@@ -5,7 +5,7 @@ use crate::traits::haslength::HasLength;
 use crate::{AxisType, Tensor};
 use crate::buffer_iterator::BufferIterator;
 
-impl<T: RawDataType> Tensor<T> {
+impl<T: RawDataType> Tensor<'_, T> {
     pub fn flatiter(&self) -> FlatIterator<T> {
         FlatIterator::from(self)
     }
@@ -15,7 +15,7 @@ impl<T: RawDataType> Tensor<T> {
     }
 }
 
-impl<T: RawDataType> Tensor<T> {
+impl<T: RawDataType> Tensor<'_, T> {
     pub fn iter(&self) -> NdIterator<T> {
         NdIterator::from(self, [0])
     }

--- a/src/tensor/iterator/mod.rs
+++ b/src/tensor/iterator/mod.rs
@@ -5,5 +5,4 @@ pub mod tensor_iterator;
 
 pub(super) mod collapse_contiguous;
 mod util;
-
-pub use iterators::*;
+mod flat_iterator;

--- a/src/tensor/iterator/tensor_iterator.rs
+++ b/src/tensor/iterator/tensor_iterator.rs
@@ -59,7 +59,7 @@ where
             return None;
         }
 
-        let return_value = self.result.copy_view();
+        let return_value = self.result.view();
         self.iterator_index += 1;
 
         for i in (0..self.shape.len()).rev() {

--- a/src/tensor/iterator/tensor_iterator.rs
+++ b/src/tensor/iterator/tensor_iterator.rs
@@ -4,11 +4,8 @@ use crate::traits::haslength::HasLength;
 use crate::Tensor;
 
 #[non_exhaustive]
-pub struct NdIterator<T>
-where
-    T: RawDataType,
-{
-    result: Tensor<T>,
+pub struct NdIterator<'a, T: RawDataType> {
+    result: Tensor<'a, T>,
 
     shape: Vec<usize>,
     stride: Vec<usize>,
@@ -18,17 +15,14 @@ where
     size: usize,
 }
 
-impl<T: RawDataType> Tensor<T> {
+impl<T: RawDataType> Tensor<'_, T> {
     unsafe fn offset_ptr(&mut self, offset: isize) {
         self.ptr = self.ptr.offset(offset);
     }
 }
 
-impl<T> NdIterator<T>
-where
-    T: RawDataType,
-{
-    pub(super) fn from<I>(tensor: &Tensor<T>, axes: I) -> Self
+impl<'a, T: RawDataType> NdIterator<'a, T> {
+    pub(super) fn from<I>(tensor: &'a Tensor<T>, axes: I) -> Self
     where
         I: IntoIterator<Item=usize> + HasLength + Clone,
     {
@@ -48,13 +42,12 @@ where
     }
 }
 
-impl<T> Iterator for NdIterator<T>
-where
-    T: RawDataType,
-{
-    type Item = Tensor<T>;
+impl<'a, T: RawDataType> Iterator for NdIterator<'a, T> {
+    type Item = Tensor<'a, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        return None;
+
         if self.iterator_index == self.size {
             return None;
         }

--- a/src/tensor/methods.rs
+++ b/src/tensor/methods.rs
@@ -2,7 +2,7 @@ use crate::dtype::RawDataType;
 use crate::tensor::flags::TensorFlags;
 use crate::Tensor;
 
-impl<T: RawDataType> Tensor<T> {
+impl<T: RawDataType> Tensor<'_, T> {
     #[inline]
     pub fn shape(&self) -> &[usize] {
         &self.shape

--- a/src/tensor/reshape.rs
+++ b/src/tensor/reshape.rs
@@ -2,7 +2,11 @@ use crate::dtype::RawDataType;
 use crate::tensor::flags::TensorFlags;
 use crate::{Axis, Tensor};
 
-impl<T: RawDataType> Tensor<T> {
+impl<'a, T: RawDataType> Tensor<'a, T> {
+    pub fn flatten<'b>(&self) -> Tensor<'b, T> {
+        unsafe { Tensor::from_contiguous_owned_buffer(vec![self.size()], self.clone_data()) }
+    }
+
     pub(super) unsafe fn reshaped_view(&self, shape: Vec<usize>, stride: Vec<usize>) -> Tensor<T> {
         Tensor {
             ptr: self.ptr,
@@ -12,18 +16,16 @@ impl<T: RawDataType> Tensor<T> {
             shape,
             stride,
             flags: self.flags - TensorFlags::Owned,
+
+            _marker: self._marker,
         }
     }
 
-    pub fn view(&self) -> Tensor<T> {
+    pub fn view(&'a self) -> Tensor<'a, T> {
         unsafe { self.reshaped_view(self.shape.clone(), self.stride.clone()) }
     }
 
-    pub fn flatten(&self) -> Tensor<T> {
-        unsafe { Tensor::from_contiguous_owned_buffer(vec![self.size()], self.clone_data()) }
-    }
-
-    pub fn squeeze(&self) -> Tensor<T> {
+    pub fn squeeze(&'a self) -> Tensor<'a, T> {
         let mut shape = self.shape.clone();
         let mut stride = self.stride.clone();
 
@@ -34,7 +36,7 @@ impl<T: RawDataType> Tensor<T> {
         unsafe { self.reshaped_view(shape, stride) }
     }
 
-    pub fn unsqueeze(&self, axis: Axis) -> Tensor<T> {
+    pub fn unsqueeze(&'a self, axis: Axis) -> Tensor<'a, T> {
         let axis = axis.0;
         assert!(axis <= self.ndims(), "Tensor::unsqueeze(), axis out of bounds");
 

--- a/src/tensor/reshape.rs
+++ b/src/tensor/reshape.rs
@@ -15,7 +15,7 @@ impl<T: RawDataType> Tensor<T> {
         }
     }
 
-    pub(super) fn copy_view(&self) -> Tensor<T> {
+    pub fn view(&self) -> Tensor<T> {
         unsafe { self.reshaped_view(self.shape.clone(), self.stride.clone()) }
     }
 

--- a/src/tensor/slice.rs
+++ b/src/tensor/slice.rs
@@ -9,7 +9,7 @@ use crate::Tensor;
 fn update_flags_with_contiguity(mut flags: TensorFlags, shape: &[usize], stride: &[usize]) -> TensorFlags {
     flags -= TensorFlags::Owned;
 
-    if is_contiguous(&shape, &stride) {
+    if is_contiguous(shape, stride) {
         flags | TensorFlags::Contiguous
     } else {
         flags - TensorFlags::Contiguous
@@ -30,7 +30,7 @@ fn calculate_strided_buffer_length(shape: &[usize], stride: &[usize]) -> usize {
 
 
 impl<'a, T: RawDataType> Tensor<'a, T> {
-    pub fn slice_along<S: Indexer>(&self, axis: Axis, index: S) -> Tensor<T> {
+    pub fn slice_along<S: Indexer>(&'a self, axis: Axis, index: S) -> Tensor<'a, T> {
         let axis = axis.0;
 
         let mut new_shape = self.shape.clone();
@@ -61,7 +61,7 @@ impl<'a, T: RawDataType> Tensor<'a, T> {
         }
     }
 
-    pub fn slice<S, I>(&self, index: I) -> Tensor<T>
+    pub fn slice<S, I>(&'a self, index: I) -> Tensor<'a, T>
     where
         S: Indexer,
         I: IntoIterator<Item=S>,

--- a/src/tensor/slice.rs
+++ b/src/tensor/slice.rs
@@ -8,12 +8,21 @@ use crate::Tensor;
 
 
 impl<'a, T: RawDataType> Tensor<'a, T> {
-    pub fn slice_along<S>(&self, axis: Axis, index: S) -> Tensor<T>
-    where
-        S: Indexer,
-    {
-        let (shape, stride) = index.indexed_shape_and_stride(&axis, &self.shape, &self.stride);
-        let offset = self.stride[axis.0] * index.index_of_first_element();
+    pub fn slice_along<S: Indexer>(&self, axis: Axis, index: S) -> Tensor<T> {
+        let axis = axis.0;
+
+        let mut shape = self.shape.clone();
+        let mut stride = self.stride.clone();
+
+        if index.collapse_dimension() {
+            shape.remove(axis);
+            stride.remove(axis);
+        }
+        else {
+            shape[axis] = index.indexed_length(shape[axis]);
+        }
+
+        let offset = self.stride[axis] * index.index_of_first_element();
 
         // let mut len = 1;
         // for i in 0..ndims {
@@ -55,19 +64,58 @@ impl<'a, T: RawDataType> Tensor<'a, T> {
         // if the dimension of the tensor is preserved during the slice along, we increment the axis
         // otherwise the axis isn't incremented because the previous dimension has collapsed
 
-        // let mut axis = 0;
-        // let mut ndims = self.ndims();
-        let mut result = self.view();
+        let ndims = self.ndims();
+        let mut offset = 0;
+        let mut i = 0;
 
-        // for idx in index {
-        //     result = result.slice_along(Axis(axis), idx.clone());
-        //
-        //     if result.ndims() == ndims {
-        //         axis += 1;
-        //     } else {
-        //         ndims = result.ndims();
-        //     }
+        let mut new_shape = Vec::with_capacity(ndims);
+        let mut new_stride = Vec::with_capacity(ndims);
+
+        for idx in index {
+            offset += self.stride[i] * idx.index_of_first_element();
+
+            if idx.collapse_dimension() {} else {
+                let new_length = idx.indexed_length(self.shape[i]);
+                // TODO what if new_length is 0?
+                new_shape.push(new_length);
+                new_stride.push(self.stride[i]);
+            }
+
+            i += 1;
+        }
+
+        for j in i..ndims {
+            new_shape.push(self.shape[j]);
+            new_stride.push(self.stride[j]);
+        }
+
+        // let mut len = 1;
+        // for i in 0..ndims {
+        //     len += stride[i] * (shape[i] - 1);
         // }
-        result
+        //
+        // the following code is equivalent to the above loop
+        let len = new_shape.iter().zip(new_stride.iter())
+            .map(|(&axis_length, &axis_stride)| axis_stride * (axis_length - 1))
+            .sum::<usize>() + 1;
+
+        let mut flags = self.flags - TensorFlags::Owned;
+        if is_contiguous(&new_shape, &new_stride) {
+            flags |= TensorFlags::Contiguous;
+        } else {
+            flags -= TensorFlags::Contiguous;
+        }
+
+        Tensor {
+            ptr: unsafe { self.ptr.add(offset) },
+            len,
+            capacity: len,
+
+            shape: new_shape,
+            stride: new_stride,
+            flags,
+
+            _marker: self._marker,
+        }
     }
 }

--- a/src/tensor/slice.rs
+++ b/src/tensor/slice.rs
@@ -6,48 +6,55 @@ use crate::iterator::collapse_contiguous::is_contiguous;
 use crate::tensor::flags::TensorFlags;
 use crate::Tensor;
 
+fn update_flags_with_contiguity(mut flags: TensorFlags, shape: &[usize], stride: &[usize]) -> TensorFlags {
+    flags -= TensorFlags::Owned;
+
+    if is_contiguous(&shape, &stride) {
+        flags | TensorFlags::Contiguous
+    } else {
+        flags - TensorFlags::Contiguous
+    }
+}
+
+fn calculate_strided_buffer_length(shape: &[usize], stride: &[usize]) -> usize {
+    // let mut len = 1;
+    // for i in 0..ndims {
+    //     len += stride[i] * (shape[i] - 1);
+    // }
+    //
+    // the following code is equivalent to the above loop
+    shape.iter().zip(stride.iter())
+        .map(|(&axis_length, &axis_stride)| axis_stride * (axis_length - 1))
+        .sum::<usize>() + 1
+}
+
 
 impl<'a, T: RawDataType> Tensor<'a, T> {
     pub fn slice_along<S: Indexer>(&self, axis: Axis, index: S) -> Tensor<T> {
         let axis = axis.0;
 
-        let mut shape = self.shape.clone();
-        let mut stride = self.stride.clone();
+        let mut new_shape = self.shape.clone();
+        let mut new_stride = self.stride.clone();
 
         if index.collapse_dimension() {
-            shape.remove(axis);
-            stride.remove(axis);
-        }
-        else {
-            shape[axis] = index.indexed_length(shape[axis]);
+            new_shape.remove(axis);
+            new_stride.remove(axis);
+        } else {
+            new_shape[axis] = index.indexed_length(new_shape[axis]);
         }
 
         let offset = self.stride[axis] * index.index_of_first_element();
 
-        // let mut len = 1;
-        // for i in 0..ndims {
-        //     len += stride[i] * (shape[i] - 1);
-        // }
-        //
-        // the following code is equivalent to the above loop
-        let len = shape.iter().zip(stride.iter())
-            .map(|(&axis_length, &axis_stride)| axis_stride * (axis_length - 1))
-            .sum::<usize>() + 1;
-
-        let mut flags = self.flags - TensorFlags::Owned;
-        if is_contiguous(&shape, &stride) {
-            flags |= TensorFlags::Contiguous;
-        } else {
-            flags -= TensorFlags::Contiguous;
-        }
+        let len = calculate_strided_buffer_length(&new_shape, &new_stride);
+        let flags = update_flags_with_contiguity(self.flags, &new_shape, &new_stride);
 
         Tensor {
             ptr: unsafe { self.ptr.add(offset) },
             len,
             capacity: len,
 
-            shape,
-            stride,
+            shape: new_shape,
+            stride: new_stride,
             flags,
 
             _marker: self._marker,
@@ -59,52 +66,31 @@ impl<'a, T: RawDataType> Tensor<'a, T> {
         S: Indexer,
         I: IntoIterator<Item=S>,
     {
-        // repeatedly calls the slice_along() method for each element in the index
-        // we keep a track of which axis to slice along using the axis variable
-        // if the dimension of the tensor is preserved during the slice along, we increment the axis
-        // otherwise the axis isn't incremented because the previous dimension has collapsed
-
         let ndims = self.ndims();
         let mut offset = 0;
-        let mut i = 0;
+        let mut axis = 0;
 
         let mut new_shape = Vec::with_capacity(ndims);
         let mut new_stride = Vec::with_capacity(ndims);
 
         for idx in index {
-            offset += self.stride[i] * idx.index_of_first_element();
-
-            if idx.collapse_dimension() {} else {
-                let new_length = idx.indexed_length(self.shape[i]);
-                // TODO what if new_length is 0?
+            if !idx.collapse_dimension() {
+                let new_length = idx.indexed_length(self.shape[axis]);
                 new_shape.push(new_length);
-                new_stride.push(self.stride[i]);
+                new_stride.push(self.stride[axis]);
             }
 
-            i += 1;
+            offset += self.stride[axis] * idx.index_of_first_element();
+            axis += 1;
         }
 
-        for j in i..ndims {
+        for j in axis..ndims {
             new_shape.push(self.shape[j]);
             new_stride.push(self.stride[j]);
         }
 
-        // let mut len = 1;
-        // for i in 0..ndims {
-        //     len += stride[i] * (shape[i] - 1);
-        // }
-        //
-        // the following code is equivalent to the above loop
-        let len = new_shape.iter().zip(new_stride.iter())
-            .map(|(&axis_length, &axis_stride)| axis_stride * (axis_length - 1))
-            .sum::<usize>() + 1;
-
-        let mut flags = self.flags - TensorFlags::Owned;
-        if is_contiguous(&new_shape, &new_stride) {
-            flags |= TensorFlags::Contiguous;
-        } else {
-            flags -= TensorFlags::Contiguous;
-        }
+        let len = calculate_strided_buffer_length(&new_shape, &new_stride);
+        let flags = update_flags_with_contiguity(self.flags, &new_shape, &new_stride);
 
         Tensor {
             ptr: unsafe { self.ptr.add(offset) },

--- a/src/tensor/slice.rs
+++ b/src/tensor/slice.rs
@@ -55,7 +55,7 @@ impl<T: RawDataType> Tensor<T> {
 
         let mut axis = 0;
         let mut ndims = self.ndims();
-        let mut result = self.copy_view();
+        let mut result = self.view();
 
         for idx in index {
             result = result.slice_along(Axis(axis), idx.clone());

--- a/src/tensor/slice.rs
+++ b/src/tensor/slice.rs
@@ -7,7 +7,7 @@ use crate::tensor::flags::TensorFlags;
 use crate::Tensor;
 
 
-impl<T: RawDataType> Tensor<T> {
+impl<'a, T: RawDataType> Tensor<'a, T> {
     pub fn slice_along<S>(&self, axis: Axis, index: S) -> Tensor<T>
     where
         S: Indexer,
@@ -40,6 +40,8 @@ impl<T: RawDataType> Tensor<T> {
             shape,
             stride,
             flags,
+
+            _marker: self._marker,
         }
     }
 
@@ -53,19 +55,19 @@ impl<T: RawDataType> Tensor<T> {
         // if the dimension of the tensor is preserved during the slice along, we increment the axis
         // otherwise the axis isn't incremented because the previous dimension has collapsed
 
-        let mut axis = 0;
-        let mut ndims = self.ndims();
+        // let mut axis = 0;
+        // let mut ndims = self.ndims();
         let mut result = self.view();
 
-        for idx in index {
-            result = result.slice_along(Axis(axis), idx.clone());
-
-            if result.ndims() == ndims {
-                axis += 1;
-            } else {
-                ndims = result.ndims();
-            }
-        }
+        // for idx in index {
+        //     result = result.slice_along(Axis(axis), idx.clone());
+        //
+        //     if result.ndims() == ndims {
+        //         axis += 1;
+        //     } else {
+        //         ndims = result.ndims();
+        //     }
+        // }
         result
     }
 }

--- a/tests/tensor.rs
+++ b/tests/tensor.rs
@@ -603,3 +603,15 @@ fn test_fill_slice() {
     a.slice(s![1, ..]).fill(true);
     assert_eq!(a, correct);
 }
+
+#[test]
+fn test_compile_fail() {
+    let mut a;
+
+    {
+        let b = Tensor::zeros(10);
+        a = b.view();
+    }
+
+    a.fill(5);
+}

--- a/tests/tensor.rs
+++ b/tests/tensor.rs
@@ -290,14 +290,14 @@ fn clone_contiguous() {
     ]);
 
     let view = a.slice([..]);
-    view.clone();
+    let _ = view.clone();
 
     assert_eq!(view[[0, 0, 0]], 10);
     assert_eq!(view[[2, 1, 2]], 27);
 
     let a = Tensor::from(vec![5; 10]);
     let view = a.slice([..]);
-    view.clone();
+    let _ = view.clone();
 
     assert_eq!(view[0], 5);
     assert_eq!(view[9], 5);

--- a/tests/tensor.rs
+++ b/tests/tensor.rs
@@ -603,15 +603,3 @@ fn test_fill_slice() {
     a.slice(s![1, ..]).fill(true);
     assert_eq!(a, correct);
 }
-
-#[test]
-fn test_compile_fail() {
-    let mut a;
-
-    {
-        let b = Tensor::zeros(10);
-        a = b.view();
-    }
-
-    a.fill(5);
-}

--- a/tests/tensor.rs
+++ b/tests/tensor.rs
@@ -585,17 +585,17 @@ fn test_fill_f64() {
 
 #[test]
 fn test_fill_slice() {
-    let mut a: Tensor<i32> = Tensor::zeros([3, 5]);
+    let a: Tensor<i32> = Tensor::zeros([3, 5]);
     let correct = Tensor::from([[0, 5, 0, 0, 0], [0, 5, 0, 0, 0], [0, 5, 0, 0, 0]]);
     a.slice(s![.., 1]).fill(5);
     assert_eq!(a, correct);
 
-    let mut a: Tensor<u32> = Tensor::zeros([3, 5]);
+    let a: Tensor<u32> = Tensor::zeros([3, 5]);
     let correct: Tensor<u32> = Tensor::from([[0, 5, 5, 5, 0], [0, 5, 5, 5, 0], [0, 5, 5, 5, 0]]);
     a.slice(s![.., 1..4]).fill(5);
     assert_eq!(a, correct);
 
-    let mut a: Tensor<bool> = Tensor::zeros([3, 5]);
+    let a: Tensor<bool> = Tensor::zeros([3, 5]);
     let correct: Tensor<bool> = Tensor::from(
         [[false, false, false, false, false],
             [true, true, true, true, true],

--- a/tests/tensor.rs
+++ b/tests/tensor.rs
@@ -582,3 +582,24 @@ fn test_fill_f64() {
     a.fill(20.0);
     assert!(a.flatiter().all(|x| x == 20.0));
 }
+
+#[test]
+fn test_fill_slice() {
+    let mut a: Tensor<i32> = Tensor::zeros([3, 5]);
+    let correct = Tensor::from([[0, 5, 0, 0, 0], [0, 5, 0, 0, 0], [0, 5, 0, 0, 0]]);
+    a.slice(s![.., 1]).fill(5);
+    assert_eq!(a, correct);
+
+    let mut a: Tensor<u32> = Tensor::zeros([3, 5]);
+    let correct: Tensor<u32> = Tensor::from([[0, 5, 5, 5, 0], [0, 5, 5, 5, 0], [0, 5, 5, 5, 0]]);
+    a.slice(s![.., 1..4]).fill(5);
+    assert_eq!(a, correct);
+
+    let mut a: Tensor<bool> = Tensor::zeros([3, 5]);
+    let correct: Tensor<bool> = Tensor::from(
+        [[false, false, false, false, false],
+            [true, true, true, true, true],
+            [false, false, false, false, false]]);
+    a.slice(s![1, ..]).fill(true);
+    assert_eq!(a, correct);
+}


### PR DESCRIPTION
In previous versions, code like the following would compile without error:

```rust
fn undefined_behaviour() {
    let mut a;

    {
        let b = Tensor::zeros([3, 5]);
        a = b.view();
    }

    a.fill(50);
}
```

Even though `a` is a view into Tensor `b` which is destroyed once its scope ends, the library still allowed you to use `a`. With added lifetime generics for Tensor, code like this now generates a compiler error.
```